### PR TITLE
Compress

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+v0.2 2019-01-14 Paris (France)
+------------------------------
+
+* Add pretty-printer
+* Randomize `pop` action on the fuzzer
+* Add tests on `Rke` and `Rke.Weighted` (with `alcotest`)
+* Fix bug retrieved by `ocaml-git` (see 453633b)
+* Add `rev_iter` function
+* Fix bug on `Rke.N.keep_exn` (see 3951501)
+* Add Travis CI support
+
 v0.1 2018-12-20 Paris (France)
 ------------------------------
 

--- a/bench/bench_with_bechamel.ml
+++ b/bench/bench_with_bechamel.ml
@@ -161,4 +161,4 @@ let () =
   let raw_results = List.map (Benchmark.all ~run:3000 ~quota:Benchmark.(s 1.5) instances) tests in
   let results = List.map (fun raw_results -> List.map (fun instance -> Analyze.all ols instance raw_results) instances |> Analyze.merge ols instances) raw_results in
   let rect = { Bechamel_notty.w= 80; h= 1 } in
-  List.iter (Notty_unix.eol <.> Bechamel_notty.Multiple.image_of_ols_results ~rect ~predictor:Measure.run) results
+  List.iter (Notty_unix.(output_image <.> eol) <.> Bechamel_notty.Multiple.image_of_ols_results ~rect ~predictor:Measure.run) results

--- a/bench/bench_with_bechamel.ml
+++ b/bench/bench_with_bechamel.ml
@@ -1,33 +1,5 @@
-open Toolkit
 open Bechamel
-
-module Realtime_clock = struct
-  type label = string
-  type witness = unit
-  type value = int64 ref
-
-  let load () = ()
-  let unload () = ()
-  let make () = ()
-  let label () = "realtime-clock"
-  let epsilon () = {contents= 0L}
-  let blit () v = v := Oclock.gettime Oclock.realtime
-  let diff a b = {contents= Int64.sub !b !a}
-  let float x = Int64.to_float !x
-end
-
-module Extension = struct
-  include Extension
-
-  let realtime_clock = Measure.make (module Realtime_clock)
-end
-
-module Instance = struct
-  include Instance
-
-  let realtime_clock =
-    Measure.instance (module Realtime_clock) Extension.realtime_clock
-end
+open Toolkit
 
 let random ln =
   let ic = open_in "/dev/urandom" in
@@ -212,38 +184,13 @@ let pp_ransac_results : (string, Analyze.RANSAC.t) Hashtbl.t Fmt.t =
         (pad 30 @@ test_name)
         pp_ransac_result result )
 
-let reporter ppf =
-  let report src level ~over k msgf =
-    let k _ = over () ; k () in
-    let with_src_and_stamp h _ k fmt =
-      let dt = Mtime.Span.to_us (Mtime_clock.elapsed ()) in
-      Fmt.kpf k ppf
-        ("%s %a %a: @[" ^^ fmt ^^ "@]@.")
-        (pad 20 (Fmt.strf "%+04.0fus" dt))
-        Logs_fmt.pp_header (level, h)
-        Fmt.(styled `Magenta string)
-        (pad 20 @@ Logs.Src.name src)
-    in
-    msgf @@ fun ?header ?tags fmt -> with_src_and_stamp header tags k fmt
-  in
-  {Logs.report}
-
-let setup_logs style_renderer level =
-  Fmt_tty.setup_std_outputs ?style_renderer () ;
-  Logs.set_level level ;
-  Logs.set_reporter (reporter Fmt.stdout) ;
-  let quiet = match style_renderer with Some _ -> true | None -> false in
-  (quiet, Fmt.stdout)
-
-let _, _ = setup_logs (Some `Ansi_tty) (Some Logs.Debug)
+let (<.>) f g = fun x -> f (g x)
 
 let () =
-  let ols =
-    Analyze.ols ~r_square:true ~bootstrap:0 ~predictors:Measure.[|run|]
-  in
-  let ransac = Analyze.ransac ~filter_outliers:true ~predictor:Measure.run in
-  let instances =
-    Instance.[minor_allocated; major_allocated; cpu_clock; realtime_clock]
+  let ols = Analyze.ols ~r_square:true ~bootstrap:0 ~predictors:Measure.[|run|] in
+  let instances = Instance.[ minor_allocated
+                           ; major_allocated
+                           ; Bechamel_perf.Instance.cpu_clock ]
   in
   let tests =
     match Sys.argv with
@@ -254,49 +201,7 @@ let () =
     | [|_; "all"|] -> tests_push @ tests_big_push @ tests_push_and_pop
     | _ -> Fmt.invalid_arg "%s {push|all}" Sys.argv.(1)
   in
-  let ols_results = Hashtbl.create (List.length instances) in
-  let ransac_results = Hashtbl.create (List.length instances) in
-  let () =
-    List.iter
-      (fun x -> Hashtbl.add ols_results (Measure.label x) (Hashtbl.create 16))
-      instances
-  in
-  let () =
-    List.iter
-      (fun x ->
-        Hashtbl.add ransac_results (Measure.label x) (Hashtbl.create 16) )
-      instances
-  in
-  let measure_and_analyze test =
-    let results =
-      Benchmark.all ~stabilize:true ~quota:(Benchmark.s 2.) ~run:5000 instances
-        test
-    in
-    List.iter
-      (fun x ->
-        let r = Analyze.all ols x results in
-        Hashtbl.add
-          (Hashtbl.find ols_results (Measure.label x))
-          (Test.name test) r )
-      instances ;
-    List.iter
-      (fun x ->
-        let r = Analyze.all ransac x results in
-        Hashtbl.add
-          (Hashtbl.find ransac_results (Measure.label x))
-          (Test.name test) r )
-      instances
-  in
-  let () = List.iter measure_and_analyze tests in
-  Hashtbl.iter
-    (fun label results ->
-      Fmt.pr "%a: @[<v>%a@]\n%!" Label.pp label
-        Fmt.(hashtbl (using snd pp_ols_results))
-        results )
-    ols_results ;
-  Hashtbl.iter
-    (fun label results ->
-      Fmt.pr "%a: @[<v>%a@]\n%!" Label.pp label
-        Fmt.(hashtbl (using snd pp_ransac_results))
-        results )
-    ransac_results
+  let raw_results = List.map (Benchmark.all ~run:3000 ~quota:Benchmark.(s 1.5) instances) tests in
+  let results = List.map (fun raw_results -> List.map (fun instance -> Analyze.all ols instance raw_results) instances |> Analyze.merge ols instances) raw_results in
+  let rect = { Bechamel_notty.w= 80; h= 1 } in
+  List.iter (Notty_unix.output_image <.> Bechamel_notty.Multiple.image_of_ols_results ~rect ~predictor:Measure.run) results

--- a/bench/dune
+++ b/bench/dune
@@ -1,7 +1,7 @@
 (executable
  (name bench_with_bechamel)
  (modules bench_with_bechamel)
- (libraries bigstringaf fmt.tty logs.fmt mtime.clock.os oclock ke bechamel bechamel.perf))
+ (libraries notty.unix bigstringaf ke bechamel bechamel.perf bechamel.notty))
 
 (executable
  (name bench_with_core)

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,3 +1,3 @@
 (executable
  (name fuzz)
- (libraries crowbar ke))
+ (libraries crowbar bigstringaf ke))

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -230,3 +230,40 @@ let () =
   if not (Compare.rke queue rke) then
     failf "%a <> %a" Fmt.(Dump.queue int) queue (pp_rke Fmt.int) rke ;
   ()
+
+let ( >>= ) = dynamic_bind
+
+let failf fmt = Fmt.kstrf fail fmt
+
+let blit src src_off dst dst_off len =
+  let a = Bigarray.Array1.sub src src_off len in
+  let b = Bigarray.Array1.sub dst dst_off len in
+  Bigarray.Array1.blit a b
+
+let blit_from_string src src_off dst dst_off len =
+  Bigstringaf.blit_from_string src ~src_off dst ~dst_off ~len
+
+let compress_and_push =
+  map [ range 0x1000 >>= bytes_fixed; range 0x1000 >>= bytes_fixed; range (2 * 0x1000) ] @@ fun fill0 fill1 capacity ->
+  let q, capacity = Ke.Rke.Weighted.create ~capacity Bigarray.Char in
+  match Ke.Rke.Weighted.N.push q ~blit:blit_from_string ~length:String.length fill0 with
+  | Some [ fill0' ] ->
+    let fill0' = Bigstringaf.create (Bigstringaf.length fill0') in
+    Ke.Rke.Weighted.compress q ;
+    Ke.Rke.Weighted.N.keep_exn q ~blit ~length:Bigstringaf.length fill0' ;
+    (match Ke.Rke.Weighted.N.push q ~blit:blit_from_string ~length:String.length fill1 with
+     | Some [ fill1' ] ->
+       let a = Bigstringaf.memcmp_string fill0' 0 fill0 0 (String.length fill0) in
+       let b = Bigstringaf.memcmp_string fill1' 0 fill1 0 (String.length fill1) in
+       if a <> 0 || b <> 0 then failf "Queue differs from inputs"
+     | Some _ -> failf "push returns multiple payloads"
+     | None ->
+       if String.length fill0 + String.length fill1 <= capacity
+       then failf "push fails for unknow reason"
+       else bad_test ())
+  | Some _ -> failf "push returns multiple payloads."
+  | None ->
+    if String.length fill0 <= capacity
+    then failf "push fails for unknow reason"
+    else bad_test ()
+

--- a/lib/sigs.ml
+++ b/lib/sigs.ml
@@ -63,6 +63,9 @@ module type R = sig
   val create : ?capacity:int -> ('a, 'b) Bigarray.kind -> ('a, 'b) t
   (** Return a new queue, initially empty. *)
 
+  val capacity : ('a, 'b) t -> int
+  (** Returns how many objects [t] can store. *)
+
   val length : ('a, 'b) t -> int
   (** Number of elements in the queue. *)
 
@@ -93,6 +96,11 @@ module type R = sig
 
   val clear : ('a, 'b) t -> unit
   (** Discard all elements from a queue. *)
+
+  val compress : ('a, 'b) t -> unit
+  (** Compress queue, read cursor will be setted to [0] and data will be move
+     to. This operation permits to provide much more space for a
+     {!push}/{!N.push} operation - but it can not ensure enough free space. *)
 
   module N : sig
     (** The type of the internal bigarray of {!t}. *)
@@ -235,6 +243,11 @@ module Weighted = struct
 
     val clear : ('a, 'b) t -> unit
     (** Discard all elements from a queue. *)
+
+    val compress : ('a, 'b) t -> unit
+    (** Compress queue, read cursor will be setted to [0] and data will be move
+       to. This operation permits to provide much more space for a
+       {!push}/{!N.push} operation - but it can not ensure enough free space. *)
 
     module N : sig
       (** The type of the internal bigarray of {!t}. *)


### PR DESCRIPTION
`compress` function is a function to be able to use `ke` with `angstrom`. It's more about `Ke.Rke.Weighted.N.push` operation and avoid to return two _payloads_ (when a part of pushed data is at the end of the ring-buffer and the other at the beginning).

So a `compress` operation ensure a point (checked by the fuzzer), if we want to push data just after it, `Ke.Rke.Weighted.N.push` should return `Some [ payload ]` or `None`. It should be impossible to retrieve the case where data was split (where `push` returns 2 payloads).

Sorry for the noise about `Dump release v0.2` commit ...

Currently fuzzed on my server, and then be able to implement DKIM tool in one pass :+1: !