### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/ke.opam
+++ b/ke.opam
@@ -15,7 +15,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml"      {>= "4.03.0"}
-  "dune"       {build}
+  "dune"
   "fmt"
   "bigarray-compat"
   "alcotest" {with-test}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.