### PR TITLE
Require OCaml 4.08.0, remove bigarray-compat dependency and usage

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.19.0
+version=0.21.0
 module-item-spacing=compact
 break-struct=natural
 break-infix=fit-or-vertical

--- a/bench/bench_with_core.ml
+++ b/bench/bench_with_core.ml
@@ -191,4 +191,4 @@ let tests_push_and_pop =
 let command =
   Bench.make_command (tests_push @ tests_big_push @ tests_push_and_pop)
 
-let () = Command.run command
+let () = Command_unix.run command

--- a/bench/dune
+++ b/bench/dune
@@ -6,7 +6,7 @@
 (executable
  (name bench_with_core)
  (modules bench_with_core)
- (libraries bigstringaf core_bench ke core))
+ (libraries bigstringaf core_bench ke core core_unix.command_unix))
 
 (rule
  (alias runbench)

--- a/ke.opam
+++ b/ke.opam
@@ -23,7 +23,7 @@ depends: [
   "bechamel-notty"    {with-test}
   "bechamel-perf"     {with-test}
   "ocplib-json-typed" {with-test}
-  "core_bench"        {with-test}
+  "core_bench"        {with-test & >= "v0.15"}
   "lwt"               {with-test}
   "crowbar"           {with-test}
   "rresult"           {with-test}

--- a/ke.opam
+++ b/ke.opam
@@ -14,10 +14,9 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
-  "ocaml"      {>= "4.03.0"}
+  "ocaml"      {>= "4.08.0"}
   "dune"       {>= "2.0"}
   "fmt"        {>= "0.8.7"}
-  "bigarray-compat"
   "alcotest"          {with-test}
   "bigstringaf"       {with-test}
   "bechamel"          {with-test}

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name ke)
  (public_name ke)
- (libraries fmt bigarray-compat))
+ (libraries fmt))

--- a/lib/fke.ml
+++ b/lib/fke.ml
@@ -186,8 +186,8 @@ module Weighted = struct
     r : int;
     w : int;
     c : int;
-    k : ('a, 'b) Bigarray_compat.kind;
-    v : ('a, 'b, Bigarray_compat.c_layout) Bigarray_compat.Array1.t;
+    k : ('a, 'b) Bigarray.kind;
+    v : ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t;
   }
 
   exception Empty
@@ -225,25 +225,25 @@ module Weighted = struct
         w = 0;
         c = capacity;
         k = kind;
-        v = Bigarray_compat.Array1.create kind Bigarray_compat.c_layout capacity;
+        v = Bigarray.Array1.create kind Bigarray.c_layout capacity;
       },
       capacity )
 
   let copy t =
-    let v = Bigarray_compat.Array1.create t.k Bigarray_compat.c_layout t.c in
-    Bigarray_compat.Array1.blit t.v v;
+    let v = Bigarray.Array1.create t.k Bigarray.c_layout t.c in
+    Bigarray.Array1.blit t.v v;
     { r = t.r; w = t.w; c = t.c; v; k = t.k }
 
   let from v =
-    if not (is_power_of_two (Bigarray_compat.Array1.dim v)) then
+    if not (is_power_of_two (Bigarray.Array1.dim v)) then
       Fmt.invalid_arg "RBA.from";
-    let c = Bigarray_compat.Array1.dim v in
-    let k = Bigarray_compat.Array1.kind v in
+    let c = Bigarray.Array1.dim v in
+    let k = Bigarray.Array1.kind v in
     { r = 0; w = 0; c; k; v }
 
   let push_exn t v =
     if (full [@inlined]) t then raise Full;
-    Bigarray_compat.Array1.unsafe_set t.v ((mask [@inlined]) t t.w) v;
+    Bigarray.Array1.unsafe_set t.v ((mask [@inlined]) t t.w) v;
     { t with w = t.w + 1 }
 
   let push t v = try Some (push_exn t v) with Full -> None
@@ -251,27 +251,27 @@ module Weighted = struct
   let cons_exn t v =
     if (full [@inlined]) t then raise Full;
     let i = t.r - 1 in
-    Bigarray_compat.Array1.unsafe_set t.v ((mask [@inlined]) t i) v;
+    Bigarray.Array1.unsafe_set t.v ((mask [@inlined]) t i) v;
     { t with r = i }
 
   let cons t v = try Some (cons_exn t v) with Full -> None
 
   let pop_exn t =
     if (empty [@inlined]) t then raise Empty;
-    let r = Bigarray_compat.Array1.unsafe_get t.v ((mask [@inlined]) t t.r) in
+    let r = Bigarray.Array1.unsafe_get t.v ((mask [@inlined]) t t.r) in
     (r, { t with r = t.r + 1 })
 
   let pop t = try Some (pop_exn t) with Empty -> None
 
   let peek_exn t =
     if (empty [@inlined]) t then raise Empty;
-    Bigarray_compat.Array1.unsafe_get t.v ((mask [@inlined]) t t.r)
+    Bigarray.Array1.unsafe_get t.v ((mask [@inlined]) t t.r)
 
   let peek t = try Some (peek_exn t) with Empty -> None
 
   module N = struct
     type ('a, 'b) bigarray =
-      ('a, 'b, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
+      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
 
     type ('a, 'b) blit = 'a -> int -> 'b -> int -> int -> unit
     type 'a length = 'a -> int
@@ -287,12 +287,12 @@ module Weighted = struct
           blit v off t.v msk pre;
           blit v (off + pre) t.v 0 rst;
           [
-            Bigarray_compat.Array1.sub t.v ((mask [@inlined]) t t.w) pre;
-            Bigarray_compat.Array1.sub t.v 0 rst;
+            Bigarray.Array1.sub t.v ((mask [@inlined]) t t.w) pre;
+            Bigarray.Array1.sub t.v 0 rst;
           ])
         else (
           blit v off t.v msk len;
-          [ Bigarray_compat.Array1.sub t.v ((mask [@inlined]) t t.w) len ])
+          [ Bigarray.Array1.sub t.v ((mask [@inlined]) t t.w) len ])
       in
       (ret, { t with w = t.w + len })
 
@@ -326,7 +326,7 @@ module Weighted = struct
     let idx = ref t.r in
     let max = t.w in
     while !idx <> max do
-      f (Bigarray_compat.Array1.unsafe_get t.v ((mask [@inlined]) t !idx));
+      f (Bigarray.Array1.unsafe_get t.v ((mask [@inlined]) t !idx));
       incr idx
     done
 
@@ -336,7 +336,7 @@ module Weighted = struct
       let idx = ref (pred t.w) in
       let min = t.r in
       while
-        f (Bigarray_compat.Array1.unsafe_get t.v ((mask [@inlined]) t !idx));
+        f (Bigarray.Array1.unsafe_get t.v ((mask [@inlined]) t !idx));
         !idx <> min
       do
         decr idx

--- a/lib/fke.ml
+++ b/lib/fke.ml
@@ -270,9 +270,7 @@ module Weighted = struct
   let peek t = try Some (peek_exn t) with Empty -> None
 
   module N = struct
-    type ('a, 'b) bigarray =
-      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
-
+    type ('a, 'b) bigarray = ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
     type ('a, 'b) blit = 'a -> int -> 'b -> int -> int -> unit
     type 'a length = 'a -> int
 

--- a/lib/rke.ml
+++ b/lib/rke.ml
@@ -112,9 +112,7 @@ let compress t =
       blit t.v 0 t.v pre rst;
       blit t.v msk t.v 0 pre)
     else
-      let tmp =
-        Bigarray.Array1.create t.k Bigarray.c_layout pre
-      in
+      let tmp = Bigarray.Array1.create t.k Bigarray.c_layout pre in
       blit t.v msk tmp 0 pre;
       blit t.v 0 t.v pre rst;
       blit tmp 0 t.v 0 pre)
@@ -123,9 +121,7 @@ let compress t =
   t.w <- len
 
 module N = struct
-  type ('a, 'b) bigarray =
-    ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
-
+  type ('a, 'b) bigarray = ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
   type ('a, 'b) blit = 'a -> int -> 'b -> int -> int -> unit
   type 'a length = 'a -> int
 
@@ -163,10 +159,7 @@ module N = struct
       let pre = t.c - msk in
       let rst = len - pre in
       if rst > 0 then
-        [
-          Bigarray.Array1.sub t.v msk pre;
-          Bigarray.Array1.sub t.v 0 rst;
-        ]
+        [ Bigarray.Array1.sub t.v msk pre; Bigarray.Array1.sub t.v 0 rst ]
       else [ Bigarray.Array1.sub t.v msk len ]
 
   let unsafe_shift t len = t.r <- t.r + len
@@ -300,9 +293,7 @@ module Weighted = struct
         blit t.v 0 t.v pre rst;
         blit t.v msk t.v 0 pre)
       else
-        let tmp =
-          Bigarray.Array1.create t.k Bigarray.c_layout pre
-        in
+        let tmp = Bigarray.Array1.create t.k Bigarray.c_layout pre in
         blit t.v msk tmp 0 pre;
         blit t.v 0 t.v pre rst;
         blit tmp 0 t.v 0 pre)
@@ -311,9 +302,7 @@ module Weighted = struct
     t.w <- len
 
   module N = struct
-    type ('a, 'b) bigarray =
-      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
-
+    type ('a, 'b) bigarray = ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
     type ('a, 'b) blit = 'a -> int -> 'b -> int -> int -> unit
     type 'a length = 'a -> int
 
@@ -363,10 +352,7 @@ module Weighted = struct
         let pre = t.c - msk in
         let rst = len - pre in
         if rst > 0 then
-          [
-            Bigarray.Array1.sub t.v msk pre;
-            Bigarray.Array1.sub t.v 0 rst;
-          ]
+          [ Bigarray.Array1.sub t.v msk pre; Bigarray.Array1.sub t.v 0 rst ]
         else [ Bigarray.Array1.sub t.v msk len ]
 
     let unsafe_shift t len = t.r <- t.r + len

--- a/lib/sigs.ml
+++ b/lib/sigs.ml
@@ -71,7 +71,7 @@ module type R = sig
   val is_empty : ('a, 'b) t -> bool
   (** Return [true] if the given queue is empty, [false] otherwise. *)
 
-  val create : ?capacity:int -> ('a, 'b) Bigarray_compat.kind -> ('a, 'b) t
+  val create : ?capacity:int -> ('a, 'b) Bigarray.kind -> ('a, 'b) t
   (** Return a new queue, initially empty. *)
 
   val capacity : ('a, 'b) t -> int
@@ -115,7 +115,7 @@ module type R = sig
 
   module N : sig
     type ('a, 'b) bigarray =
-      ('a, 'b, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
+      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
     (** The type of the internal bigarray of {!t}. *)
 
     type ('a, 'b) blit = 'a -> int -> 'b -> int -> int -> unit
@@ -163,7 +163,7 @@ module type R = sig
 
     val peek :
       ('a, 'b) t ->
-      ('a, 'b, Bigarray_compat.c_layout) Bigarray_compat.Array1.t list
+      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t list
     (** Returns a sub-part of available to read payloads. *)
 
     val unsafe_shift : ('a, 'b) t -> int -> unit
@@ -216,7 +216,7 @@ module Weighted = struct
     (** Return [true] if the given queue is empty, [false] otherwise. *)
 
     val create :
-      ?capacity:int -> ('a, 'b) Bigarray_compat.kind -> ('a, 'b) t * int
+      ?capacity:int -> ('a, 'b) Bigarray.kind -> ('a, 'b) t * int
     (** Return a new queue, initially empty with the real capacity of it. *)
 
     val length : ('a, 'b) t -> int
@@ -269,7 +269,7 @@ module Weighted = struct
 
     module N : sig
       type ('a, 'b) bigarray =
-        ('a, 'b, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
+        ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
       (** The type of the internal bigarray of {!t}. *)
 
       type ('a, 'b) blit = 'a -> int -> 'b -> int -> int -> unit
@@ -330,7 +330,7 @@ module Weighted = struct
 
       val peek :
         ('a, 'b) t ->
-        ('a, 'b, Bigarray_compat.c_layout) Bigarray_compat.Array1.t list
+        ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t list
       (** Returns a sub-part of available to read payloads. *)
 
       val unsafe_shift : ('a, 'b) t -> int -> unit
@@ -368,11 +368,11 @@ module Weighted = struct
     (** Human-readable pretty-printer of {!t}. *)
 
     val unsafe_bigarray :
-      ('a, 'b) t -> ('a, 'b, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
+      ('a, 'b) t -> ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
     (** / **)
 
     val from :
-      ('a, 'b, Bigarray_compat.c_layout) Bigarray_compat.Array1.t -> ('a, 'b) t
+      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t -> ('a, 'b) t
   end
 
   module type F = sig
@@ -389,7 +389,7 @@ module Weighted = struct
     (** Return [true] if the given queue is empty, [false] otherwise. *)
 
     val create :
-      ?capacity:int -> ('a, 'b) Bigarray_compat.kind -> ('a, 'b) t * int
+      ?capacity:int -> ('a, 'b) Bigarray.kind -> ('a, 'b) t * int
     (** Return a new queue, initially empty with the real capacity of it. *)
 
     val length : ('a, 'b) t -> int
@@ -438,7 +438,7 @@ module Weighted = struct
 
     module N : sig
       type ('a, 'b) bigarray =
-        ('a, 'b, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
+        ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
       (** The type of the internal bigarray of {!t}. *)
 
       type ('a, 'b) blit = 'a -> int -> 'b -> int -> int -> unit
@@ -534,9 +534,9 @@ module Weighted = struct
     (** / **)
 
     val unsafe_bigarray :
-      ('a, 'b) t -> ('a, 'b, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
+      ('a, 'b) t -> ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
 
     val from :
-      ('a, 'b, Bigarray_compat.c_layout) Bigarray_compat.Array1.t -> ('a, 'b) t
+      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t -> ('a, 'b) t
   end
 end

--- a/lib/sigs.ml
+++ b/lib/sigs.ml
@@ -114,8 +114,7 @@ module type R = sig
      {!push}/{!N.push} operation - but it can not ensure enough free space. *)
 
   module N : sig
-    type ('a, 'b) bigarray =
-      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
+    type ('a, 'b) bigarray = ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
     (** The type of the internal bigarray of {!t}. *)
 
     type ('a, 'b) blit = 'a -> int -> 'b -> int -> int -> unit
@@ -161,9 +160,7 @@ module type R = sig
       unit option
     (** Same as {!keep_exn} but if it fails, it returns [None]. *)
 
-    val peek :
-      ('a, 'b) t ->
-      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t list
+    val peek : ('a, 'b) t -> ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t list
     (** Returns a sub-part of available to read payloads. *)
 
     val unsafe_shift : ('a, 'b) t -> int -> unit
@@ -215,8 +212,7 @@ module Weighted = struct
     val is_empty : ('a, 'b) t -> bool
     (** Return [true] if the given queue is empty, [false] otherwise. *)
 
-    val create :
-      ?capacity:int -> ('a, 'b) Bigarray.kind -> ('a, 'b) t * int
+    val create : ?capacity:int -> ('a, 'b) Bigarray.kind -> ('a, 'b) t * int
     (** Return a new queue, initially empty with the real capacity of it. *)
 
     val length : ('a, 'b) t -> int
@@ -268,8 +264,7 @@ module Weighted = struct
        {!push}/{!N.push} operation - but it can not ensure enough free space. *)
 
     module N : sig
-      type ('a, 'b) bigarray =
-        ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
+      type ('a, 'b) bigarray = ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
       (** The type of the internal bigarray of {!t}. *)
 
       type ('a, 'b) blit = 'a -> int -> 'b -> int -> int -> unit
@@ -329,8 +324,7 @@ module Weighted = struct
       (** Same as {!keep_exn} but if it fails, it returns [None]. *)
 
       val peek :
-        ('a, 'b) t ->
-        ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t list
+        ('a, 'b) t -> ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t list
       (** Returns a sub-part of available to read payloads. *)
 
       val unsafe_shift : ('a, 'b) t -> int -> unit
@@ -371,8 +365,7 @@ module Weighted = struct
       ('a, 'b) t -> ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
     (** / **)
 
-    val from :
-      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t -> ('a, 'b) t
+    val from : ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t -> ('a, 'b) t
   end
 
   module type F = sig
@@ -388,8 +381,7 @@ module Weighted = struct
     val is_empty : ('a, 'b) t -> bool
     (** Return [true] if the given queue is empty, [false] otherwise. *)
 
-    val create :
-      ?capacity:int -> ('a, 'b) Bigarray.kind -> ('a, 'b) t * int
+    val create : ?capacity:int -> ('a, 'b) Bigarray.kind -> ('a, 'b) t * int
     (** Return a new queue, initially empty with the real capacity of it. *)
 
     val length : ('a, 'b) t -> int
@@ -437,8 +429,7 @@ module Weighted = struct
     (** Discard all elements from a queue. *)
 
     module N : sig
-      type ('a, 'b) bigarray =
-        ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
+      type ('a, 'b) bigarray = ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
       (** The type of the internal bigarray of {!t}. *)
 
       type ('a, 'b) blit = 'a -> int -> 'b -> int -> int -> unit
@@ -536,7 +527,6 @@ module Weighted = struct
     val unsafe_bigarray :
       ('a, 'b) t -> ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
 
-    val from :
-      ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t -> ('a, 'b) t
+    val from : ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t -> ('a, 'b) t
   end
 end


### PR DESCRIPTION
This is a package very deep in the dependency chain that requires bigarray-compat. But does anyone use this package with OCaml < 4.08.0?